### PR TITLE
Added Action Attribute Because It Makes The Plugin Work

### DIFF
--- a/src/dotnet/ReSharperPlugin.TestLinker2/Actions/GotoLinkedTypes2Action.cs
+++ b/src/dotnet/ReSharperPlugin.TestLinker2/Actions/GotoLinkedTypes2Action.cs
@@ -1,4 +1,5 @@
 using JetBrains.Application.DataContext;
+using JetBrains.Application.UI.ActionsRevised.Menu;
 using JetBrains.Application.UI.ActionSystem.ActionsRevised.Menu;
 using JetBrains.ReSharper.Feature.Services.Actions;
 using JetBrains.ReSharper.Feature.Services.Navigation.ContextNavigation;
@@ -6,8 +7,12 @@ using ReSharperPlugin.TestLinker2.Navigation;
 
 namespace ReSharperPlugin.TestLinker2.Actions
 {
-	public class GotoLinkedTypes2Action
-		: ContextNavigationActionBase<LinkedTypesNavigationProvider>
+	[Action(
+		Id,
+		"Goto Linked Types (Test/Production)",
+		IdeaShortcuts = new[] {"Shift+Control+I"},
+		VsShortcuts = new[] {"Shift+Control+I"})]
+	public class GotoLinkedTypes2Action : ContextNavigationActionBase<LinkedTypesNavigationProvider>
 	{
 		public const string Id = nameof(GotoLinkedTypes2Action);
 


### PR DESCRIPTION
I have seen this issue #9,  that mentions that the plugin is working in version 2022.2 but not in 2022.2.1.
I found a commit the is removing the `Action` attribute from `GotoLinkedTypes2Action`, Commit : https://github.com/vladyslav-burylov/resharper-testlinker2/commit/4823f270ef0feb793781029e24675bdfbc8b7cdf

You mentioned in the commit that the `Action` attribute is deprecated, but the constructor is the one that is deprecated.
The Attribute is seems the be needed that the action will work.